### PR TITLE
Add viewport meta tag to control mobile layout

### DIFF
--- a/index.template.html
+++ b/index.template.html
@@ -3,6 +3,7 @@
   <head>
     <title>{%=o.htmlWebpackPlugin.options.title || 'Redux React Router Async Example'%}</title>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
     {% if (o.htmlWebpackPlugin.files.favicon) { %}
     <link rel="shortcut icon" href="{%=o.htmlWebpackPlugin.files.favicon%}">


### PR DESCRIPTION
Fixed the missing viewport meta tag.
